### PR TITLE
Release version 2.0.1

### DIFF
--- a/de.darmstadt.tu.crossing.CrySL.feature/feature.xml
+++ b/de.darmstadt.tu.crossing.CrySL.feature/feature.xml
@@ -2,7 +2,7 @@
 <feature
       id="de.darmstadt.tu.crossing.CrySL.feature"
       label="de.darmstadt.tu.crossing.CrySL.feature"
-      version="2.0.0"
+      version="2.0.1"
       provider-name="Technical University Darmstadt, Paderborn University"
       plugin="https://it.crossing.tu-darmstadt.de/cognicrypt/">
 
@@ -139,21 +139,21 @@ Exhibit A – Form of Secondary Licenses Notice
          id="de.darmstadt.tu.crossing.CrySL"
          download-size="0"
          install-size="0"
-         version="2.0.0"
+         version="2.0.1"
          unpack="false"/>
 
    <plugin
          id="de.darmstadt.tu.crossing.CrySL.ide"
          download-size="0"
          install-size="0"
-         version="2.0.0"
+         version="2.0.1"
          unpack="false"/>
 
    <plugin
          id="de.darmstadt.tu.crossing.CrySL.ui"
          download-size="0"
          install-size="0"
-         version="2.0.0"
+         version="2.0.1"
          unpack="false"/>
 
 </feature>

--- a/de.darmstadt.tu.crossing.CrySL.feature/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.feature/pom.xml
@@ -1,4 +1,5 @@
-<project
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.feature</artifactId>
@@ -6,7 +7,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 </project>

--- a/de.darmstadt.tu.crossing.CrySL.ide/META-INF/MANIFEST.MF
+++ b/de.darmstadt.tu.crossing.CrySL.ide/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: de.darmstadt.tu.crossing.CrySL.ide
 Bundle-Vendor: Technical University Darmstadt, Paderborn University
-Bundle-Version: 2.0.0
+Bundle-Version: 2.0.1
 Bundle-SymbolicName: de.darmstadt.tu.crossing.CrySL.ide; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: de.darmstadt.tu.crossing.CrySL,

--- a/de.darmstadt.tu.crossing.CrySL.ide/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.ide/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.ide</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/de.darmstadt.tu.crossing.CrySL.repository/category.xml
+++ b/de.darmstadt.tu.crossing.CrySL.repository/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/de.darmstadt.tu.crossing.CrySL.feature_2.0.0.jar" id="de.darmstadt.tu.crossing.CrySL.feature" version="2.0.0">
+   <feature url="features/de.darmstadt.tu.crossing.CrySL.feature_2.0.1.jar" id="de.darmstadt.tu.crossing.CrySL.feature" version="2.0.1">
       <category name="CrySL"/>
    </feature>
    <category-def name="CrySL" label="CrySL"/>

--- a/de.darmstadt.tu.crossing.CrySL.repository/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.repository/pom.xml
@@ -1,4 +1,5 @@
-<project
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.repository</artifactId>
@@ -6,7 +7,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 	<build>

--- a/de.darmstadt.tu.crossing.CrySL.target/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.target/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.target</artifactId>
 	<packaging>eclipse-target-definition</packaging>

--- a/de.darmstadt.tu.crossing.CrySL.tests/META-INF/MANIFEST.MF
+++ b/de.darmstadt.tu.crossing.CrySL.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: de.darmstadt.tu.crossing.CrySL.tests
 Bundle-Vendor: Technical University Darmstadt, Paderborn University
-Bundle-Version: 2.0.0
+Bundle-Version: 2.0.1
 Bundle-SymbolicName: de.darmstadt.tu.crossing.CrySL.tests; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: de.darmstadt.tu.crossing.CrySL,

--- a/de.darmstadt.tu.crossing.CrySL.tests/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/de.darmstadt.tu.crossing.CrySL.ui.tests/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.ui.tests/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.ui.tests</artifactId>
 	<packaging>eclipse-test-plugin</packaging>

--- a/de.darmstadt.tu.crossing.CrySL.ui/META-INF/MANIFEST.MF
+++ b/de.darmstadt.tu.crossing.CrySL.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: de.darmstadt.tu.crossing.CrySL.ui
 Bundle-Vendor: Technical University Darmstadt, Paderborn University
-Bundle-Version: 2.0.0
+Bundle-Version: 2.0.1
 Bundle-SymbolicName: de.darmstadt.tu.crossing.CrySL.ui; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: de.darmstadt.tu.crossing.CrySL,

--- a/de.darmstadt.tu.crossing.CrySL.ui/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL.ui/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.ui</artifactId>
 	<packaging>eclipse-plugin</packaging>

--- a/de.darmstadt.tu.crossing.CrySL/META-INF/MANIFEST.MF
+++ b/de.darmstadt.tu.crossing.CrySL/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: de.darmstadt.tu.crossing.CrySL
 Bundle-Vendor: Technical University Darmstadt, Paderborn University
-Bundle-Version: 2.0.0
+Bundle-Version: 2.0.1
 Bundle-SymbolicName: de.darmstadt.tu.crossing.CrySL; singleton:=true
 Bundle-ActivationPolicy: lazy
 Require-Bundle: org.eclipse.xtext,

--- a/de.darmstadt.tu.crossing.CrySL/pom.xml
+++ b/de.darmstadt.tu.crossing.CrySL/pom.xml
@@ -5,9 +5,9 @@
 	<parent>
 		<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
 		<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1</version>
 	</parent>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<artifactId>de.darmstadt.tu.crossing.CrySL</artifactId>
 	<packaging>eclipse-plugin</packaging>
 

--- a/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/serializer/CrySLSemanticSequencer.java
+++ b/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/serializer/CrySLSemanticSequencer.java
@@ -1015,7 +1015,7 @@ public class CrySLSemanticSequencer extends XtypeSemanticSequencer {
 	 *     Primary returns Expression
 	 *
 	 * Constraint:
-	 *     ((orderEv+=[Event|ID] (elementop='+' | elementop='?' | elementop='*')?)? elementop='+'? ((elementop='?' | elementop='*')? elementop='+'?)*)
+	 *     ((orderEv+=[Event|ID] (elementop='+' | elementop='?' | elementop='*')?)? elementop='?'? ((elementop='+' | elementop='*')? elementop='?'?)*)
 	 */
 	protected void sequence_Primary(ISerializationContext context, Expression semanticObject) {
 		genericSequencer.createSequence(context, semanticObject);

--- a/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/serializer/CrySLSemanticSequencer.java
+++ b/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/serializer/CrySLSemanticSequencer.java
@@ -1015,7 +1015,7 @@ public class CrySLSemanticSequencer extends XtypeSemanticSequencer {
 	 *     Primary returns Expression
 	 *
 	 * Constraint:
-	 *     ((orderEv+=[Event|ID] (elementop='+' | elementop='?' | elementop='*')?)? elementop='?'? ((elementop='+' | elementop='*')? elementop='?'?)*)
+	 *     ((orderEv+=[Event|ID] (elementop='+' | elementop='?' | elementop='*')?)? elementop='+'? ((elementop='?' | elementop='*')? elementop='+'?)*)
 	 */
 	protected void sequence_Primary(ISerializationContext context, Expression semanticObject) {
 		genericSequencer.createSequence(context, semanticObject);

--- a/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/services/CrySLGrammarAccess.java
+++ b/de.darmstadt.tu.crossing.CrySL/src-gen/de/darmstadt/tu/crossing/services/CrySLGrammarAccess.java
@@ -72,10 +72,10 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		
 		//Domainmodel:
 		//	'SPEC' javaType=[jvmTypes::JvmType|QualifiedName] (array="[]" | "<"
-		//	collection=[jvmTypes::JvmGenericType|QualifiedName] ">")? 'OBJECTS' usage=UseBlock ('FORBIDDEN'
-		//	forbEvent=ForbiddenBlock)? 'EVENTS' req_events=RequiredBlock 'ORDER' order=Order ('CONSTRAINTS'
-		//	reqConstraints=EnforceConsBlock)? ('REQUIRES' require=RequiresBlock)? ('ENSURES' ensure=EnsuresBlock)? ('NEGATES'
-		//	destroy=DestroysBlock)?;
+		//	collection=[jvmTypes::JvmGenericType|QualifiedName] ">")?
+		//	'OBJECTS' usage=UseBlock ('FORBIDDEN' forbEvent=ForbiddenBlock)?
+		//	'EVENTS' req_events=RequiredBlock 'ORDER' order=Order ('CONSTRAINTS' reqConstraints=EnforceConsBlock)? ('REQUIRES'
+		//	require=RequiresBlock)? ('ENSURES' ensure=EnsuresBlock)? ('NEGATES' destroy=DestroysBlock)?;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//'SPEC' javaType=[jvmTypes::JvmType|QualifiedName] (array="[]" | "<" collection=[jvmTypes::JvmGenericType|QualifiedName]
@@ -368,7 +368,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final Keyword cAsteriskKeyword_1 = (Keyword)cAlternatives.eContents().get(1);
 		
 		//////////////// OBJECTS
-		// ObjectDecl:
+		//ObjectDecl:
 		//	objectType=[jvmTypes::JvmType|QualifiedName] (array="[]" | "<" collection=JvmParameterizedTypeRef ">")?
 		//	objectName=Object ";" | '*';
 		@Override public ParserRule getRule() { return rule; }
@@ -572,7 +572,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final Keyword cSemicolonKeyword_1 = (Keyword)cGroup.eContents().get(1);
 		
 		///////////// FORBIDDEN EVENTS
-		// ForbMethod:
+		//ForbMethod:
 		//	(javaMeth=[jvmTypes::JvmExecutable|FQN] ("=>" rep=[Event])?) ';';
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -691,7 +691,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final Keyword cAsteriskKeyword_2 = (Keyword)cAlternatives.eContents().get(2);
 		
 		/////////////// EVENTS
-		// Event:
+		//Event:
 		//	LabelMethodCall | Aggregate | '*';
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -717,7 +717,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cMethMethodParserRuleCall_2_0 = (RuleCall)cMethAssignment_2.eContents().get(0);
 		
 		///// LABELMETHCALL
-		// LabelMethodCall SuperType:
+		//LabelMethodCall SuperType:
 		//	name=ID ":" meth=Method;
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -888,7 +888,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final Keyword cSemicolonKeyword_1_3 = (Keyword)cGroup_1.eContents().get(3);
 		
 		///// AGGS
-		// Aggregate SuperType:
+		//Aggregate SuperType:
 		//	{Aggregate} (name=ID ':=' (lab+=[Event] ('|' lab+=[Event])*) ";");
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -954,7 +954,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final Keyword cAsteriskKeyword_1 = (Keyword)cAlternatives.eContents().get(1);
 		
 		/////////////// ORDER
-		// Order Expression:
+		//Order Expression:
 		//	SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -1115,7 +1115,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cLogicalImplyExpressionParserRuleCall = (RuleCall)rule.eContents().get(1);
 		
 		/////////////// CONSTRAINTS
-		// Constraint:
+		//Constraint:
 		//	LogicalImplyExpression;
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -1134,7 +1134,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cRightExpressionLogicalOrExpressionParserRuleCall_1_2_0 = (RuleCall)cRightExpressionAssignment_1_2.eContents().get(0);
 		
 		//LogicalImplyExpression Constraint:
-		//	LogicalOrExpression ({Constraint.leftExpression=current} operator=LogicalImply rightExpression=LogicalOrExpression)*;
+		//	LogicalOrExpression ({Constraint.leftExpression=current} operator=LogicalImply
+		//	rightExpression=LogicalOrExpression)*;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//LogicalOrExpression ({Constraint.leftExpression=current} operator=LogicalImply rightExpression=LogicalOrExpression)*
@@ -1188,7 +1189,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cRightExpressionLogicalAndExpressionParserRuleCall_1_2_0 = (RuleCall)cRightExpressionAssignment_1_2.eContents().get(0);
 		
 		//LogicalOrExpression Constraint:
-		//	LogicalAndExpression ({Constraint.leftExpression=current} operator=LogicalOr rightExpression=LogicalAndExpression)*;
+		//	LogicalAndExpression ({Constraint.leftExpression=current} operator=LogicalOr
+		//	rightExpression=LogicalAndExpression)*;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//LogicalAndExpression ({Constraint.leftExpression=current} operator=LogicalOr rightExpression=LogicalAndExpression)*
@@ -1242,7 +1244,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cRightExpressionComparisonExpressionParserRuleCall_1_2_0 = (RuleCall)cRightExpressionAssignment_1_2.eContents().get(0);
 		
 		//LogicalAndExpression Constraint:
-		//	ComparisonExpression ({Constraint.leftExpression=current} operator=LogicalAnd rightExpression=ComparisonExpression)*;
+		//	ComparisonExpression ({Constraint.leftExpression=current} operator=LogicalAnd
+		//	rightExpression=ComparisonExpression)*;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//ComparisonExpression ({Constraint.leftExpression=current} operator=LogicalAnd rightExpression=ComparisonExpression)*
@@ -1559,7 +1562,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cRightExpressionOperandParserRuleCall_1_1_2_0 = (RuleCall)cRightExpressionAssignment_1_1_2.eContents().get(0);
 		
 		//MultiplicationExpression Constraint:
-		//	UnaryPreExpression | Operand ({ArithmeticExpression.leftExpression=current} operator=MultiplicationOperator
+		//	UnaryPreExpression
+		//	| Operand ({ArithmeticExpression.leftExpression=current} operator=MultiplicationOperator
 		//	rightExpression=Operand)*;
 		@Override public ParserRule getRule() { return rule; }
 		
@@ -1632,7 +1636,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cEnclosedExpressionOperandParserRuleCall_1_1_0 = (RuleCall)cEnclosedExpressionAssignment_1_1.eContents().get(0);
 		
 		//UnaryPreExpression Constraint:
-		//	{UnaryPreExpression} (operator=UnaryPreOperator enclosedExpression=Operand);
+		//	{UnaryPreExpression} (operator=UnaryPreOperator
+		//	enclosedExpression=Operand);
 		@Override public ParserRule getRule() { return rule; }
 		
 		//{UnaryPreExpression} (operator=UnaryPreOperator enclosedExpression=Operand)
@@ -1666,7 +1671,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cConsParserRuleCall_1 = (RuleCall)cAlternatives.eContents().get(1);
 		
 		//Operand Constraint:
-		//	'(' Constraint ')' | Cons;
+		//	'(' Constraint ')'
+		//	| Cons;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//'(' Constraint ')' | Cons
@@ -2274,8 +2280,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		
 		//ConsPred LiteralExpression:
 		//	(consPred="alg(" lit=LiteralExpression ")" | consPred="mode(" lit=LiteralExpression ")" | consPred="pad("
-		//	lit=LiteralExpression ")") | part="part(" ind=IntegerLiteral "," split=StringLiteral "," lit=LiteralExpression ")" |
-		//	lit=LiteralExpression;
+		//	lit=LiteralExpression ")") | part="part(" ind=IntegerLiteral "," split=StringLiteral "," lit=LiteralExpression ")"
+		//	| lit=LiteralExpression;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//(consPred="alg(" lit=LiteralExpression ")" | consPred="mode(" lit=LiteralExpression ")" | consPred="pad("
@@ -2485,7 +2491,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 		private final RuleCall cRightExpressionPredLitParserRuleCall_1_2_0 = (RuleCall)cRightExpressionAssignment_1_2.eContents().get(0);
 		
 		//ReqPred:
-		//	PredLit ({ReqPred.leftExpression=current} operator=LogicalOr rightExpression=PredLit)*;
+		//	PredLit ({ReqPred.leftExpression=current} operator=LogicalOr
+		//	rightExpression=PredLit)*;
 		@Override public ParserRule getRule() { return rule; }
 		
 		//PredLit ({ReqPred.leftExpression=current} operator=LogicalOr rightExpression=PredLit)*
@@ -2868,10 +2875,10 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	
 	//Domainmodel:
 	//	'SPEC' javaType=[jvmTypes::JvmType|QualifiedName] (array="[]" | "<"
-	//	collection=[jvmTypes::JvmGenericType|QualifiedName] ">")? 'OBJECTS' usage=UseBlock ('FORBIDDEN'
-	//	forbEvent=ForbiddenBlock)? 'EVENTS' req_events=RequiredBlock 'ORDER' order=Order ('CONSTRAINTS'
-	//	reqConstraints=EnforceConsBlock)? ('REQUIRES' require=RequiresBlock)? ('ENSURES' ensure=EnsuresBlock)? ('NEGATES'
-	//	destroy=DestroysBlock)?;
+	//	collection=[jvmTypes::JvmGenericType|QualifiedName] ">")?
+	//	'OBJECTS' usage=UseBlock ('FORBIDDEN' forbEvent=ForbiddenBlock)?
+	//	'EVENTS' req_events=RequiredBlock 'ORDER' order=Order ('CONSTRAINTS' reqConstraints=EnforceConsBlock)? ('REQUIRES'
+	//	require=RequiresBlock)? ('ENSURES' ensure=EnsuresBlock)? ('NEGATES' destroy=DestroysBlock)?;
 	public DomainmodelElements getDomainmodelAccess() {
 		return pDomainmodel;
 	}
@@ -2951,7 +2958,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//////////////// OBJECTS
-	// ObjectDecl:
+	//ObjectDecl:
 	//	objectType=[jvmTypes::JvmType|QualifiedName] (array="[]" | "<" collection=JvmParameterizedTypeRef ">")?
 	//	objectName=Object ";" | '*';
 	public ObjectDeclElements getObjectDeclAccess() {
@@ -2994,7 +3001,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	///////////// FORBIDDEN EVENTS
-	// ForbMethod:
+	//ForbMethod:
 	//	(javaMeth=[jvmTypes::JvmExecutable|FQN] ("=>" rep=[Event])?) ';';
 	public ForbMethodElements getForbMethodAccess() {
 		return pForbMethod;
@@ -3025,7 +3032,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	/////////////// EVENTS
-	// Event:
+	//Event:
 	//	LabelMethodCall | Aggregate | '*';
 	public EventElements getEventAccess() {
 		return pEvent;
@@ -3036,7 +3043,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	///// LABELMETHCALL
-	// LabelMethodCall SuperType:
+	//LabelMethodCall SuperType:
 	//	name=ID ":" meth=Method;
 	public LabelMethodCallElements getLabelMethodCallAccess() {
 		return pLabelMethodCall;
@@ -3077,7 +3084,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	///// AGGS
-	// Aggregate SuperType:
+	//Aggregate SuperType:
 	//	{Aggregate} (name=ID ':=' (lab+=[Event] ('|' lab+=[Event])*) ";");
 	public AggregateElements getAggregateAccess() {
 		return pAggregate;
@@ -3088,7 +3095,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	/////////////// ORDER
-	// Order Expression:
+	//Order Expression:
 	//	SimpleOrder ({Order.left=current} orderop=',' right=SimpleOrder)* | '*';
 	public OrderElements getOrderAccess() {
 		return pOrder;
@@ -3119,7 +3126,7 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	/////////////// CONSTRAINTS
-	// Constraint:
+	//Constraint:
 	//	LogicalImplyExpression;
 	public ConstraintElements getConstraintAccess() {
 		return pConstraint;
@@ -3130,7 +3137,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//LogicalImplyExpression Constraint:
-	//	LogicalOrExpression ({Constraint.leftExpression=current} operator=LogicalImply rightExpression=LogicalOrExpression)*;
+	//	LogicalOrExpression ({Constraint.leftExpression=current} operator=LogicalImply
+	//	rightExpression=LogicalOrExpression)*;
 	public LogicalImplyExpressionElements getLogicalImplyExpressionAccess() {
 		return pLogicalImplyExpression;
 	}
@@ -3150,7 +3158,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//LogicalOrExpression Constraint:
-	//	LogicalAndExpression ({Constraint.leftExpression=current} operator=LogicalOr rightExpression=LogicalAndExpression)*;
+	//	LogicalAndExpression ({Constraint.leftExpression=current} operator=LogicalOr
+	//	rightExpression=LogicalAndExpression)*;
 	public LogicalOrExpressionElements getLogicalOrExpressionAccess() {
 		return pLogicalOrExpression;
 	}
@@ -3170,7 +3179,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//LogicalAndExpression Constraint:
-	//	ComparisonExpression ({Constraint.leftExpression=current} operator=LogicalAnd rightExpression=ComparisonExpression)*;
+	//	ComparisonExpression ({Constraint.leftExpression=current} operator=LogicalAnd
+	//	rightExpression=ComparisonExpression)*;
 	public LogicalAndExpressionElements getLogicalAndExpressionAccess() {
 		return pLogicalAndExpression;
 	}
@@ -3274,7 +3284,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//MultiplicationExpression Constraint:
-	//	UnaryPreExpression | Operand ({ArithmeticExpression.leftExpression=current} operator=MultiplicationOperator
+	//	UnaryPreExpression
+	//	| Operand ({ArithmeticExpression.leftExpression=current} operator=MultiplicationOperator
 	//	rightExpression=Operand)*;
 	public MultiplicationExpressionElements getMultiplicationExpressionAccess() {
 		return pMultiplicationExpression;
@@ -3295,7 +3306,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//UnaryPreExpression Constraint:
-	//	{UnaryPreExpression} (operator=UnaryPreOperator enclosedExpression=Operand);
+	//	{UnaryPreExpression} (operator=UnaryPreOperator
+	//	enclosedExpression=Operand);
 	public UnaryPreExpressionElements getUnaryPreExpressionAccess() {
 		return pUnaryPreExpression;
 	}
@@ -3305,7 +3317,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//Operand Constraint:
-	//	'(' Constraint ')' | Cons;
+	//	'(' Constraint ')'
+	//	| Cons;
 	public OperandElements getOperandAccess() {
 		return pOperand;
 	}
@@ -3438,8 +3451,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	
 	//ConsPred LiteralExpression:
 	//	(consPred="alg(" lit=LiteralExpression ")" | consPred="mode(" lit=LiteralExpression ")" | consPred="pad("
-	//	lit=LiteralExpression ")") | part="part(" ind=IntegerLiteral "," split=StringLiteral "," lit=LiteralExpression ")" |
-	//	lit=LiteralExpression;
+	//	lit=LiteralExpression ")") | part="part(" ind=IntegerLiteral "," split=StringLiteral "," lit=LiteralExpression ")"
+	//	| lit=LiteralExpression;
 	public ConsPredElements getConsPredAccess() {
 		return pConsPred;
 	}
@@ -3475,7 +3488,8 @@ public class CrySLGrammarAccess extends AbstractGrammarElementFinder {
 	}
 	
 	//ReqPred:
-	//	PredLit ({ReqPred.leftExpression=current} operator=LogicalOr rightExpression=PredLit)*;
+	//	PredLit ({ReqPred.leftExpression=current} operator=LogicalOr
+	//	rightExpression=PredLit)*;
 	public ReqPredElements getReqPredAccess() {
 		return pReqPred;
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.darmstadt.tu.crossing.CrySL</groupId>
-	<version>2.0.0</version>
+	<version>2.0.1</version>
 	<artifactId>de.darmstadt.tu.crossing.CrySL.parent</artifactId>
 	<packaging>pom</packaging>
 


### PR DESCRIPTION
This release is necessary, because 2.0.0 got an API critical change 
```
PredLit::getCons():Constraint --> PredLit::getCons():EObject
PredLit::setCons(Constraint) --> PredLit::setCons(EObject)
```
In a consequence we noticed some linking errors in our build environments. 

Releasing a new version seems to be the easiest and cleanest fix.  