### PR TITLE
Create YAML file for GitHub Actions CI

### DIFF
--- a/.github/workflows/main_build.yml
+++ b/.github/workflows/main_build.yml
@@ -1,0 +1,136 @@
+name: CrySL build
+
+on: [push, pull_request]
+
+jobs:
+
+  # Builds the project in Windows
+  windows-build:
+    # Runs on Windows
+    runs-on: windows-latest
+    name: Project build in Windows
+    steps:
+      # Downloads CrySL repository
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      # Sets up Java version
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: '8'
+      # Sets up Maven version
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: 3.6.3
+      # Checks Java version
+      - name: Check Java version
+        run: java -version
+      # Checks Maven version
+      - name: Check Maven version
+        run: mvn -version
+      # Restores Maven dependecies
+      - name: Restore local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      # Compiles, tests, and packages the CrySL project
+      - name: Compile, test, and package the project
+        run: mvn -B clean install -U
+  
+  
+  
+  # Builds the project in Ubuntu
+  ubuntu-build:
+    # Runs on Ubuntu
+    runs-on: ubuntu-latest
+    name: Project build in Ubuntu
+    steps:
+      # Downloads CrySL repository
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      # Sets up Java version
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: '8'
+      # Sets up Maven version
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: 3.6.3
+      # Checks Java version
+      - name: Check Java version
+        run: java -version
+      # Checks Maven version
+      - name: Check Maven version
+        run: mvn -version
+      # Restores Maven dependecies
+      - name: Restore local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      # Compiles, tests, and packages the CrySL project
+      - name: Compile, test, and package the project
+        run: mvn -B clean install -U
+  
+  
+  
+  # Builds the project in macOS
+  macos-build:
+    # Runs on macOS
+    runs-on: macos-latest
+    name: Project build in macOS
+    steps:
+      # Downloads CrySL repository
+      - name: Checkout source code
+        uses: actions/checkout@v2
+      # Sets up Java version
+      - name: Set up Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: '8'
+      # Sets up Maven version
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: 3.6.3
+      # Checks Java version
+      - name: Check Java version
+        run: java -version
+      # Checks Maven version
+      - name: Check Maven version
+        run: mvn -version
+      # Restores Maven dependecies
+      - name: Restore local Maven repository
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      # Compiles, tests, and packages the CrySL project
+      - name: Compile, test, and package the project
+        run: mvn -B clean install -U
+        
+
+# REFERENCES
+
+# The following link is a short guide for learning GitHub Actions:
+# https://docs.github.com/en/actions/learn-github-actions
+
+# We are using Gitub-hosted runners or servers that build our project.
+# Up-to-date details about runners and their versions can be found under:
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners


### PR DESCRIPTION
This pull request introduces in our repository a new CI, GitHub Actions. The latter is a built-in tool in GitHub, where the CrySL repository is also located. Also, we don't need to set up the build operation from our own server, because Actions offers their own server, where we can choose to do each build simultaneously in many operating systems. If our project is open-source, which it is, Actions offers all its capabilities free of charge. As far as I have tried it, it has a very simple and nice UI, which makes it easy to navigate. Lastly, it is backed by a large open-source community and one can helpful solutions for a wide range of problems, without needing to do much research.