### PR TITLE
Action to update the CrySL version after each merge on the master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,13 @@
-name: deploy
+name: Deploy CrySL
 
+# This workflow runs after the version has been updated
+# If there are any problems with the updates, CrySL will not be deployed
+# This action only runs on the default branch
 on:
-  push:
-    branches:
-      - master
+  workflow_run:
+    workflows: ["Update CrySL version"]
+    types:
+      - completed
 
 jobs:
   build:
@@ -11,6 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Project build in ${{ matrix.os }}
     steps:
       - name: Checkout source code
@@ -27,7 +32,7 @@ jobs:
           server-password: OSSRH_PASSWORD # Env var that holds your OSSRH user pw
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }} # Substituted with the value stored in the referenced secret
           gpg-passphrase: SIGN_KEY_PASS # Env var that holds the key's passphrase
-      - name: Build & Deploy
+      - name: Build & Deploy CrySL
         run: mvn -B -U clean deploy
         env:
           SIGN_KEY_PASS: ${{ secrets.GPG_PRIVATE_KEY_PASSPHRASE }}

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -1,0 +1,54 @@
+name: Update CrySL version
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+
+jobs:
+  Version-Update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # Sets up Java version
+      - name: Set up Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'adopt'
+          java-package: jdk
+          java-version: '11'
+      # Sets up Maven version
+      - name: Set up Maven
+        uses: stCarolas/setup-maven@v4.2
+        with:
+          maven-version: 3.6.3
+      # Semantic versioning
+      - name: Semantic versioning
+        id: versioning
+        uses: paulhatch/semantic-version@v5.1.0
+        with:
+          tag_prefix: ""
+        # A string which, if present in a git commit, indicates that a change represents a
+        # major (breaking) change, supports regular expressions wrapped with '/'
+          major_pattern: "(MAJOR)"
+        # Same as above except indicating a minor change, supports regular expressions wrapped with '/'
+          minor_pattern: "(MINOR)"
+        # A string to determine the format of the version output
+          version_format: "${major}.${minor}.${patch}"
+      # Bumping version
+      - name: Update version and create tag
+        run: |
+          mvn build-helper:parse-version versions:set -DnewVersion=\${{ steps.versioning.outputs.version }} versions:commit
+          mvn tycho-versions:update-eclipse-metadata
+          git ls-files | grep 'pom.xml$' | xargs git add
+          git config --global user.email "${{ github.actor }}@users.noreply.github.com"
+          git config --global user.name "${{ github.actor }}"
+          git commit -am "Update CrySL version to ${{ steps.versioning.outputs.version }}"
+          git tag ${{ steps.versioning.outputs.version }}
+          git push --atomic origin master ${{ steps.versioning.outputs.version }}


### PR DESCRIPTION
This PR adds a Github action, which updates the version of CrySL in all pom and MANIFEST files on each merge to the master branch:
- If there is the (MAJOR) keyword in one commit, the major version will change (e.g. 2.0.1 -> 3.0.0)
- If there is the (MINOR) keyword in one commit, the minor version will change (e.g. 2.0.1 -> 2.1.0)
- If there is no keyword in the commits, the patch version will change (e.g. 2.0.1 -> 2.0.2)